### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Keycloak MCP Server
 
+[![smithery badge](https://smithery.ai/badge/keycloak-model-context-protocol)](https://smithery.ai/server/keycloak-model-context-protocol)
+
 A Model Context Protocol server for Keycloak administration, providing tools to manage users and realms.
 
 ## Features
@@ -10,6 +12,14 @@ A Model Context Protocol server for Keycloak administration, providing tools to 
 - List users in specific realms
 
 ## Installation
+
+### Installing via Smithery
+
+To install Keycloak for Claude Desktop automatically via [Smithery](https://smithery.ai/server/keycloak-model-context-protocol):
+
+```bash
+npx -y @smithery/cli install keycloak-model-context-protocol --client claude
+```
 
 ### Via NPM (Recommended)
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Keycloak for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/keycloak-model-context-protocol

Let me know if any tweaks have to be made!